### PR TITLE
Fetch members that belong to a particular Twitter list

### DIFF
--- a/apps/get_list_members.rb
+++ b/apps/get_list_members.rb
@@ -10,8 +10,6 @@ Usage:
 
   <owner_screen_name>: The screen name of the list owner.
   <list_slug>: The slug of the list.
-
-The following options are supported:
 }
 
 def parse_command_line

--- a/apps/get_list_members.rb
+++ b/apps/get_list_members.rb
@@ -1,0 +1,60 @@
+require_relative '../requests/ListMemberIds'
+
+require 'trollop'
+
+USAGE = %Q{
+get_list_members: Retrieve members of a given Twitter list.
+
+Usage:
+  ruby get_list_members.rb <options> <owner_screen_name> <list_slug>
+
+  <owner_screen_name>: The screen name of the list owner.
+  <list_slug>: The slug of the list.
+
+The following options are supported:
+}
+
+def parse_command_line
+
+  options = {type: :string, required: true}
+
+  opts = Trollop::options do
+    version "get_list_members 0.1 (c) 2015 David Aragon"
+    banner USAGE
+    opt :props, "OAuth Properties File", options
+  end
+
+  unless File.exist?(opts[:props])
+    Trollop::die :props, "must point to a valid oauth properties file"
+  end
+
+  opts[:owner_screen_name] = ARGV[0]
+  opts[:list_slug] = ARGV[1]
+  opts
+end
+
+if __FILE__ == $0
+
+  STDOUT.sync = true
+
+  input  = parse_command_line
+  params = { slug: input[:list_slug], owner_screen_name: input[:owner_screen_name] }
+  data   = { props: input[:props] }
+
+  args     = { params: params, data: data }
+
+  twitter = ListMemberIds.new(args)
+
+  puts "Collecting the ids of the Twitter users that are members of list '#{input[:list_slug]}'"
+
+  File.open('list_member_ids.txt', 'w') do |f|
+    twitter.collect do |ids|
+      ids.each do |id|
+        f.puts "#{id}\n"
+      end
+    end
+  end
+
+  puts "DONE."
+
+end

--- a/requests/ListMemberIds.rb
+++ b/requests/ListMemberIds.rb
@@ -1,0 +1,32 @@
+require_relative '../core/CursorRequest'
+
+class ListMemberIds < CursorRequest
+
+  def initialize(args)
+    super args
+    params[:count] = 5000
+    @count = 0
+  end
+
+  def request_name
+    "ListMemberIds"
+  end
+
+  def twitter_endpoint
+    "/lists/members"
+  end
+
+  def url
+    'https://api.twitter.com/1.1/lists/members.json'
+  end
+
+  def success(response)
+    log.info("SUCCESS")
+    ids = JSON.parse(response.body)["users"].map { |user| user["id"] }
+    @count += ids.size
+    log.info("#{ids.size} ids received.")
+    log.info("#{@count} total ids received.")
+    yield ids
+  end
+
+end


### PR DESCRIPTION
This PR adds functionality to fetch all the members that belong to a particular Twitter list. The usage is as follows:

`ruby get_list_members.rb <options> <owner_screen_name> <list_slug>`

`<options>`: The path of your OAuth credentials file
`<owner_screen_name>`: The screen name of the list owner.
`<list_slug>`: The slug of the list.

Here are some examples to try out:

`ruby apps/get_list_members.rb --props creds.json davidostermann agency`
`ruby apps/get_list_members.rb --props creds.json Scampiuk awstweeters`
