### PR TITLE
Get recent mentions of authenticating user - Edward Zhu

### DIFF
--- a/apps/get_mentions.rb
+++ b/apps/get_mentions.rb
@@ -6,11 +6,11 @@ USAGE = %Q{
 get_mentions: Retrieve most recent mentions for a given Twitter screen_name.
 
 Usage:
-  ruby get_mentions.rb <options> <screen_name>
+  ruby /PATH/get_mentions.rb <options> <trim_user>
 
-  <screen_name>: A Twitter screen_name.
-
-The following options are supported:
+  <trim_user>: When set to either true, t or 1, each tweet 
+      returned in a timeline will include a user object 
+      including only the status authors numerical ID.
 }
 
 def parse_command_line
@@ -18,7 +18,7 @@ def parse_command_line
   options = {type: :string, required: true}
 
   opts = Trollop::options do
-    version "get_mentions 0.1 (c) 2015 Kenneth M. Anderson"
+    version "get_mentions 0.1 (c) 2015 Edward Zhu"
     banner USAGE
     opt :props, "OAuth Properties File", options
   end
@@ -27,7 +27,7 @@ def parse_command_line
     Trollop::die :props, "must point to a valid oauth properties file"
   end
 
-  opts[:screen_name] = ARGV[0]
+  opts[:trim_user] = ARGV[0]
   opts
 end
 
@@ -36,14 +36,14 @@ if __FILE__ == $0
   STDOUT.sync = true
 
   input  = parse_command_line
-  params = { screen_name: input[:screen_name] }
+  params = { trim_user: input[:trim_user] }
   data   = { props: input[:props] }
 
   args     = { params: params, data: data }
 
   twitter = MentionsTimeline.new(args)
 
-  puts "Collecting most recent mentions for '#{input[:screen_name]}'"
+  puts "Collecting most recent mentions of myself. Trimming mentions:'#{input[:trim_user]}'"
 
   File.open('mentions.json', 'w') do |f|
     twitter.collect do |mentions|

--- a/apps/get_mentions.rb
+++ b/apps/get_mentions.rb
@@ -1,0 +1,58 @@
+require_relative '../requests/MentionsTimeline'
+
+require 'trollop'
+
+USAGE = %Q{
+get_mentions: Retrieve most recent mentions for a given Twitter screen_name.
+
+Usage:
+  ruby get_mentions.rb <options> <screen_name>
+
+  <screen_name>: A Twitter screen_name.
+
+The following options are supported:
+}
+
+def parse_command_line
+
+  options = {type: :string, required: true}
+
+  opts = Trollop::options do
+    version "get_mentions 0.1 (c) 2015 Kenneth M. Anderson"
+    banner USAGE
+    opt :props, "OAuth Properties File", options
+  end
+
+  unless File.exist?(opts[:props])
+    Trollop::die :props, "must point to a valid oauth properties file"
+  end
+
+  opts[:screen_name] = ARGV[0]
+  opts
+end
+
+if __FILE__ == $0
+
+  STDOUT.sync = true
+
+  input  = parse_command_line
+  params = { screen_name: input[:screen_name] }
+  data   = { props: input[:props] }
+
+  args     = { params: params, data: data }
+
+  twitter = MentionsTimeline.new(args)
+
+  puts "Collecting most recent mentions for '#{input[:screen_name]}'"
+
+  File.open('mentions.json', 'w') do |f|
+    twitter.collect do |mentions|
+      mentions.each do |tweet|
+        f.puts "#{tweet.to_json}\n"
+      end
+    end
+  end
+
+  puts "DONE."
+
+end

--- a/requests/MentionsTimeline.rb
+++ b/requests/MentionsTimeline.rb
@@ -4,7 +4,7 @@ class MentionsTimeline < MaxIdRequest
 
   def initialize(args)
     super args
-    params[:count] = 20
+    params[:count] = 200
     @count = 0
   end
 

--- a/requests/MentionsTimeline.rb
+++ b/requests/MentionsTimeline.rb
@@ -24,25 +24,21 @@ class MentionsTimeline < MaxIdRequest
     log.info("SUCCESS")
     mentions = JSON.parse(response.body)
     @count += mentions.size
-    log.info("#{mentions.size} mention(s) received.")
-    log.info("#{@count} total mention(s) received.")
+    log.info("#{mentions.size} mention tweets received.")
+    log.info("#{@count} total tweet(s) received.")
     yield mentions
   end
 
   def init_condition
-    @num_success = 0
+    @last_count = 1
   end
 
   def condition
-    @num_success < 16
+    @last_count > 0
   end
 
-  def update_condition(mentions)
-    if mentions.size > 0
-      @num_success += 1
-    else
-      @num_success = 16
-    end
+  def update_condition(tweets)
+    @last_count = tweets.size
   end
 
 end

--- a/requests/MentionsTimeline.rb
+++ b/requests/MentionsTimeline.rb
@@ -1,0 +1,48 @@
+require_relative '../core/MaxIdRequest'
+
+class MentionsTimeline < MaxIdRequest
+
+  def initialize(args)
+    super args
+    params[:count] = 20
+    @count = 0
+  end
+
+  def request_name
+    "MentionsTimeline"
+  end
+
+  def twitter_endpoint
+    "/statuses/mentions_timeline"
+  end
+
+  def url
+    'https://api.twitter.com/1.1/statuses/mentions_timeline.json'
+  end
+
+  def success(response)
+    log.info("SUCCESS")
+    mentions = JSON.parse(response.body)
+    @count += mentions.size
+    log.info("#{mentions.size} mention(s) received.")
+    log.info("#{@count} total mention(s) received.")
+    yield mentions
+  end
+
+  def init_condition
+    @num_success = 0
+  end
+
+  def condition
+    @num_success < 16
+  end
+
+  def update_condition(mentions)
+    if mentions.size > 0
+      @num_success += 1
+    else
+      @num_success = 16
+    end
+  end
+
+end


### PR DESCRIPTION
This will add functionality to get most recent mentions (tweets containing a users’s @screen_name) for the authenticating user.

Usage:

```
ruby PATH/get_mentions.rb <options> <trim_user>
```

`<options>`: The path of your OAuth credentials file
`<trim_user>`: To trim the mention tweets or not. Setting true, t or 1, will return a timeline with user objects including only the status authors numerical ID.

Examples to test it out:

ruby apps/get_mentions.rb -p oauth.properties true 
ruby apps/get_mentions.rb -p oauth.properties false
