### PR TITLE
implemented lists/subscriptions

### DIFF
--- a/apps/get_lists_subscriptions.rb
+++ b/apps/get_lists_subscriptions.rb
@@ -1,0 +1,62 @@
+require_relative '../requests/ListsSubscriptions'
+
+require 'trollop'
+
+USAGE = %Q{
+get_lists_subscriptions: Returns a collection of lists the specified user is
+subscribed to.
+
+Usage:
+  ruby get_lists_subscriptions.rb <options> <screen_name>
+
+  <screen_name>: The screen name of the user for whom to return results for.
+
+  Example:
+  ruby get_lists_subscriptions.rb --props oath.properties episod
+}
+
+def parse_command_line
+
+  options = {type: :string, required: true}
+
+  opts = Trollop::options do
+    version "get_lists_subscriptions 0.1 (c) 2015 Kenneth M. Anderson; "\
+            "Updated by Sanghee Kim"
+    banner USAGE
+    opt :props, "OAuth Properties File", options
+  end
+
+  unless File.exist?(opts[:props])
+    Trollop::die :props, "must point to a valid oauth properties file"
+  end
+
+  opts[:screen_name] = ARGV[0]
+  opts
+end
+
+if __FILE__ == $0
+
+  STDOUT.sync = true
+
+  input  = parse_command_line
+  params = { screen_name: input[:screen_name] }
+  data   = { props: input[:props] }
+
+  args     = { params: params, data: data }
+
+  twitter = ListsSubscriptions.new(args)
+
+  puts "Obtaining a collection of the lists '#{input[:screen_name]}' "\
+        "is subscribed to"
+
+  File.open('lists_subscriptions.txt', 'w') do |f|
+    twitter.collect do |subs|
+      subs.each do |sub|
+        f.puts "#{sub}\n"
+      end
+    end
+  end
+
+  puts "DONE."
+
+end

--- a/requests/ListsSubscriptions.rb
+++ b/requests/ListsSubscriptions.rb
@@ -1,0 +1,32 @@
+require_relative '../core/CursorRequest'
+
+class ListsSubscriptions < CursorRequest
+
+  def initialize(args)
+    super args
+    params[:count] = 5000
+    @count = 0
+  end
+
+  def request_name
+    "ListsSubscriptions"
+  end
+
+  def twitter_endpoint
+    "/lists/subscriptions"
+  end
+
+  def url
+    'https://api.twitter.com/1.1/lists/subscriptions.json'
+  end
+
+  def success(response)
+    log.info("SUCCESS")
+    subs = JSON.parse(response.body)["lists"].map { |list| list["uri"] }
+    @count += subs.size
+    log.info("#{subs.size} subscriptions received.")
+    log.info("#{@count} total subscriptions received.")
+    yield subs
+  end
+
+end


### PR DESCRIPTION
Obtain a collection of the lists the specified user is subscribed to.
This will return a list of uri such as /TwitterEng/lists/team

Example:
$ ruby get_lists_subscriptions.rb --props oath.properties episod

If you want to get more properties, check the spec:

url: https://dev.twitter.com/rest/reference/get/lists/subscriptions
